### PR TITLE
Add pre-start script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ cs
    - Codex: `cs -p "codex"`
    - Aider: `cs -p "aider ..."`
 - Make this the default, by modifying the config file (locate with `cs debug`)
+- Set `pre_start_script` in the config to run a shell script after each worktree
+  is prepared
 
 <br />
 

--- a/app/app.go
+++ b/app/app.go
@@ -120,6 +120,7 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 
 	// Add loaded instances to the list
 	for _, instance := range instances {
+		instance.PreStartScript = appConfig.PreStartScript
 		// Call the finalizer immediately.
 		h.list.AddInstance(instance)()
 		if autoYes {
@@ -424,9 +425,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 				fmt.Errorf("you can't create more than %d instances", GlobalInstanceLimit))
 		}
 		instance, err := session.NewInstance(session.InstanceOptions{
-			Title:   "",
-			Path:    ".",
-			Program: m.program,
+			Title:          "",
+			Path:           ".",
+			Program:        m.program,
+			PreStartScript: m.appConfig.PreStartScript,
 		})
 		if err != nil {
 			return m, m.handleError(err)
@@ -445,9 +447,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 				fmt.Errorf("you can't create more than %d instances", GlobalInstanceLimit))
 		}
 		instance, err := session.NewInstance(session.InstanceOptions{
-			Title:   "",
-			Path:    ".",
-			Program: m.program,
+			Title:          "",
+			Path:           ".",
+			Program:        m.program,
+			PreStartScript: m.appConfig.PreStartScript,
 		})
 		if err != nil {
 			return m, m.handleError(err)

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	AutoYes bool `json:"auto_yes"`
 	// DaemonPollInterval is the interval (ms) at which the daemon polls sessions for autoyes mode.
 	DaemonPollInterval int `json:"daemon_poll_interval"`
+	// PreStartScript is an optional script run after a worktree is created
+	// or resumed.
+	PreStartScript string `json:"pre_start_script"`
 }
 
 // DefaultConfig returns the default configuration
@@ -35,6 +38,7 @@ func DefaultConfig() *Config {
 		DefaultProgram:     "claude",
 		AutoYes:            false,
 		DaemonPollInterval: 1000,
+		PreStartScript:     "",
 	}
 }
 


### PR DESCRIPTION
## Summary
- support running a pre-start shell script via new `pre_start_script` config option
- propagate the script path to new and loaded instances
- execute the script after worktrees are created or resumed
- document the new config option in the README

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`